### PR TITLE
Fix Session table definition

### DIFF
--- a/Sources/KituraSessionKuery/KueryStore.swift
+++ b/Sources/KituraSessionKuery/KueryStore.swift
@@ -12,7 +12,7 @@ public class KueryStore: Store {
 
     public class Sessions: Table {
         let tableName = "Sessions"
-        let id = Column("id", Char.self, primaryKey: true)
+        let id = Column("id", Char.self, length: 36, primaryKey: true)
         let data = Column("data", String.self)
     }
 


### PR DESCRIPTION
At least when using the Postgres Kuery package, the current session definition does not work. At runtime the session fails to persist because the provided `UUID` is longer than 1 character